### PR TITLE
docs: document canonical URL scheme across all documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Architecture: **1 standard+part+version → 1 LXR package → 1 SPA HTML file**, all listed on the index page.
 
+## Canonical URL Rule
+
+**All schemas are served at top-level URLs with NO `/schemas/` prefix.** This is non-negotiable because XML parsers, validators, and `schemaLocation` attributes depend on these URLs.
+
+| Resource | URL Pattern |
+|----------|-------------|
+| XSD file | `/{standard}/{part}/{module}/{version}/{module}.xsd` |
+| JSON schema | `/json/{standard}/{part}/{module}/{version}/{module}.json` |
+| Schema browser | `/{standard}/{part}/{module}/{version}/browse/` |
+| Namespace hub | `/{standard}/{part}/{module}/{version}/` |
+
+The `schemas/` directory is a git submodule (source files). The `BuildSourceGenerator` plugin registers files from `schemas/` as Jekyll static files, and Jekyll serves them at top-level paths (stripping the `schemas/` base dir). Never add `/schemas/` to any URL path.
+
+The `url_path()` helper in `models.rb` strips the `schemas/` prefix from paths stored in `schemas_index.json` (which reference the source directory).
+
 ## Two-Gemfile Architecture
 
 `lutaml-xsd` depends on `terminal-table` in a way incompatible with Jekyll ~> 4.3. They cannot share a single Gemfile:
@@ -47,8 +62,8 @@ make serve
 # Clean all build artifacts
 make clean
 
-# Initialize/update git submodules (schemas)
-make update-init update-modules
+# Update git submodules (schemas)
+make update
 ```
 
 ## Architecture
@@ -68,7 +83,7 @@ generate_configs.rb   → Reads manifests from schemas/ + auto-discovers resourc
 configs/              → Auto-generated per-package lutaml-xsd configs
 build/                → Intermediate LXR packages (.lxr ZIP files)
 site/                 → SPA HTML output from lutaml-xsd and lutaml-jsonschema
-_site/                → Final deployable output (Jekyll build + SPA files copied in)
+_site/                → Final deployable output (Jekyll build with SPA + schema data)
 
 _frontend/            → jekyll-vite frontend source
   entrypoints/application.js → imports theme + schemas.css + schemas.js + resources.js
@@ -78,14 +93,27 @@ _frontend/            → jekyll-vite frontend source
 config/vite.json      → jekyll-vite config (sourceCodeDir: _frontend)
 vite.config.ts        → Vite config with vite-plugin-ruby
 
+_plugins/
+  build_source_generator.rb  → Registers SPA pages from site/ and schema data files from
+                                schemas/ as Jekyll static files. Files from schemas/ are
+                                served at top-level paths (no /schemas/ prefix).
+  schema_pages_generator.rb  → Generates standard listing pages, standard root pages (for
+                                multi-part standards), and namespace hub pages. Uses
+                                HtmlHelper from models.rb for rendering.
+  redirect_generator.rb      → Post-write hook: copies data files to legacy paths, generates
+                                HTML meta-refresh redirects for directory paths.
+  schema_site/models.rb      → Shared constants (DATA_EXTENSIONS, SKIP_DIRS, RESOURCE_CATEGORIES),
+                                HtmlHelper module (esc, url_path, render_resources), Package
+                                and ModuleVersion classes.
+
 _pages/index.html     → Jekyll index page (layout: home, hero + schema cards)
 _pages/resources.html → Dynamic resource catalog (transforms, schematron, examples, etc.)
 _pages/news.html      → News listing page (layout: posts, uses theme's posts.html layout)
 _pages/docs.html      → Documentation links page
+_pages/about.html     → About page with URL structure documentation
 _posts/               → News articles (Jekyll posts, .md format, layout: post)
 _config.yml           → Jekyll config (theme, plugins, nav, excludes)
 _data/redirects.yml   → Old→new path mappings for moved files
-_plugins/redirect_generator.rb → Generates HTML redirect pages from redirects.yml
 
 Gemfile               → Site deps: Jekyll + jekyll-theme-isotc211 + jekyll-vite
 Makefile              → Build orchestration
@@ -111,14 +139,16 @@ The filesystem IS the database. `generate_configs.rb` contains a `ResourceScanne
 Manifests (`lxr_packages.yml`, `ljr_packages.yml`) provide only human metadata (title, description, status). Everything else is auto-discovered.
 
 Output files:
-- `schemas_index.json` — all packages with resource counts
-- `resources_index.json` — all resources grouped by standard → category
+- `schemas_index.json` — all packages with resource counts (paths have `schemas/` prefix for source reference)
+- `resources_index.json` — all resources grouped by standard → category (paths are already canonical)
 
 ## Redirect Strategy
 
 Two tiers for handling URL changes from directory restructuring:
 1. **jekyll-redirect-from** — page-level redirects (e.g., `/transforms/` → `/resources/`)
-2. **_plugins/redirect_generator.rb** — file-level redirects from `_data/redirects.yml`
+2. **`_plugins/redirect_generator.rb`** — file-level redirects from `_data/redirects.yml`:
+   - **Data files** (.xsd, .xml, etc.) — copies the actual target file to the old path (XML parsers can't follow HTML redirects)
+   - **HTML/directory paths** — generates HTML meta-refresh redirect page
 
 ## Schema Location Mappings
 
@@ -139,14 +169,14 @@ Defined in `generate_configs.rb`, auto-included in every lutaml-xsd config:
 
 ## Deployment
 
-GitHub Actions workflow (`.github/workflows/build_deploy.yml`) builds on push to `main` and deploys `_site/` to GitHub Pages. The schemas submodule (ISO-TC211/schemas) triggers a `repository_dispatch` event to rebuild the site on schema changes.
+GitHub Actions workflow (`.github/workflows/ci.yml`) builds on push to `main` and deploys `_site/` to GitHub Pages. The schemas submodule (ISO-TC211/schemas) triggers a `repository_dispatch` event to rebuild the site on schema changes.
 
-### SPA deployment flow
-1. `generate_configs.rb` produces per-package configs + `Makefile.spa` (with `SPA_FILES` list)
-2. `make build-all` builds LXR packages + SPA HTML files (in parallel with `-j4`)
-3. `lutaml-jsonschema` requires its frontend pre-built: `cd $(bundle show lutaml-jsonschema)/frontend && npm install && npm run build`
-4. SPA HTML files go to `site/` (excluded from Jekyll processing)
-5. After Jekyll build, `cp -r site/* _site/` copies SPA files into the deployable output
+### Build pipeline
+1. `make configs` — `generate_configs.rb` produces per-package configs + `Makefile.spa` (with `SPA_FILES` list)
+2. `make lxr-spas` — builds LXR packages + SPA HTML files in parallel (`-j4`). Also pre-builds the lutaml-jsonschema frontend.
+3. `jekyll build` — generates all pages. `BuildSourceGenerator` registers schema data files from `schemas/` at top-level paths and SPA pages from `site/`. `SchemaPagesGenerator` creates standard, hub, and root pages.
+4. Post-write hook — `redirect_generator.rb` copies data files to legacy paths and generates HTML redirects.
+5. Deploy — upload `_site/` to GitHub Pages.
 
 ## jekyll-vite note
 

--- a/README.adoc
+++ b/README.adoc
@@ -8,13 +8,85 @@ image:https://github.com/ISO-TC211/schemas-isotc211.github.io/actions/workflows/
 The ISO/TC 211 XML Schemas site publishes XML schemas from ISO/TC 211 standards at
 https://schemas.isotc211.org. Each schema package has:
 
-* **Downloadable XSD files** at `https://schemas.isotc211.org/schemas/{standard}/{-part}/{module}/{version}/`
+* **Downloadable XSD files** at their canonical URLs (no `/schemas/` prefix)
 * **Interactive schema browsers** (lutaml-xsd SPA) per standard+part+version
 * **Per-standard landing pages** at `/{standard}/` with namespace dereference pages
 * **A resource catalog** at `/resources/` (transforms, schematron, examples, codelists, bundles)
 * **A card-based index page** with filter by standard/name/description
 
 This repository is jointly managed by ISO/TC 211 and operated by Ribose.
+
+
+== URL Structure
+
+**All schemas are served at canonical top-level URLs — there is NO `/schemas/` prefix in any URL.**
+This is critical because XML parsers, validators, and `schemaLocation` attributes depend on these URLs.
+
+[cols="1,2,2"]
+|===
+| Resource | URL Pattern | Example
+
+| XML namespace
+| `/{standard}/{part}/{module}/{major}.{minor}`
+| `/19115/-1/cit/1.3`
+
+| XSD file
+| `/{standard}/{part}/{module}/{version}/{module}.xsd`
+| `/19115/-1/cit/1.3.0/cit.xsd`
+
+| JSON schema
+| `/json/{standard}/{part}/{module}/{version}/{module}.json`
+| `/json/19115/-4/mdj/1.0.0/mdj.json`
+
+| Schema browser
+| `/{standard}/{part}/{module}/{version}/browse/`
+| `/19115/-1/cit/1.3.0/browse/`
+
+| Namespace hub
+| `/{standard}/{part}/{module}/{version}/`
+| `/19115/-1/cit/1.3.0/`
+
+| Standard page
+| `/{standard}/{part}/` or `/{standard}/`
+| `/19115/-1/`
+
+| XML examples
+| `/{standard}/{part}/{module}/{version}/examples/`
+| `/19115/-1/mdb/1.3.0/examples/`
+
+| JSON examples
+| `/json/{standard}/{part}/{module}/{version}/examples/`
+| `/json/19115/-4/mdj/1.0.0/examples/`
+
+| Transforms
+| `/{standard}/resources/transforms/`
+| `/19115/resources/transforms/`
+
+| Codelists
+| `/{standard}/resources/codelists/`
+| `/19115/resources/codelists/`
+
+| Bundles
+| `/{standard}/resources/bundles/`
+| `/19115/resources/bundles/`
+|===
+
+=== Path elements
+
+Standard:: 5 digits (e.g., `19115`)
+Part:: `-1`, `-2`, `-3`, or `-` for standalone (no part)
+Module:: 3 lowercase letters (e.g., `cit`, `mdb`, `gml`)
+Version:: semantic version (e.g., `1.0`, `1.3.0`)
+
+=== Legacy redirects
+
+Some schemas were previously available at non-canonical paths (missing part number, or with `/schemas/` prefix).
+These are redirected to the canonical URLs above:
+
+* **Data files** (.xsd, .xml, etc.) — the actual file is copied to the old path (XML parsers can't follow HTML redirects)
+* **HTML/directory paths** — HTML meta-refresh redirect to the canonical URL
+
+Legacy redirects are defined in `_data/redirects.yml`.
 
 
 == Building the site
@@ -32,19 +104,19 @@ make _site            # Build the Jekyll site into _site/
 # Build a single LXR package
 make build/19136-gml-1.0.lxr
 
-# Generate a single schema browser
-make site/19136-gml-1.0.html
-
 # Clean all build artifacts
 make clean
+
+# Update git submodules (schemas)
+make update
 ----
 
 === Prerequisites
 
 * Ruby 3.3 with Bundler
 * Node.js 20 with npm
-* Git submodules initialized: `make update-init update-modules`
-* Two Gemfiles: `Gemfile` (Jekyll) and `Gemfile.lutaml` (lutaml-xsd) — they have conflicting liquid version requirements
+* Git submodules initialized: `make update`
+* Two Gemfiles: `Gemfile` (Jekyll) and `schemas/Gemfile` (lutaml-xsd) — they have conflicting dependencies
 
 
 == Architecture
@@ -63,8 +135,8 @@ Architecture: **1 standard+part+version → 1 LXR package → 1 SPA HTML file**,
 
 | `vendor_schemas/` | Helper schemas for LXR builds (xlink, w3c/xml.xsd, OGC sensorML/sweCommon)
 
-| `lxr_packages.yml` | XSD package manifest — title, description, status, file paths
-| `json_packages.yml` | JSON schema package manifest
+| `schemas/lxr_packages.yml` | XSD package manifest — title, description, status, file paths
+| `schemas/ljr_packages.yml` | JSON schema package manifest
 
 | `generate_configs.rb` | Reads manifests + auto-discovers resources from filesystem.
                           Outputs: per-package configs in `configs/`, `schemas_index.json`, `resources_index.json`
@@ -88,14 +160,21 @@ Architecture: **1 standard+part+version → 1 LXR package → 1 SPA HTML file**,
 |===
 | Plugin | Purpose
 
-| `build_source_generator.rb` | Registers SPA HTMLs (`site/*.html`) and index JSONs as Jekyll static files
-| `schema_pages_generator.rb` | Generates per-standard pages (`/{standard}/`) and per-namespace dereference pages (`/{standard}/{part}/{module}/{version}/`)
-| `redirect_generator.rb` | Generates HTML redirect pages from `_data/redirects.yml`
+| `build_source_generator.rb` | Registers SPA HTMLs from `site/` and schema data files from `schemas/`
+                                as Jekyll static files. Files from `schemas/` are served at
+                                top-level paths (no `/schemas/` prefix).
+
+| `schema_pages_generator.rb` | Generates per-standard listing pages (`/{standard}/`), multi-part
+                                root pages, and namespace hub pages
+                                (`/{standard}/{part}/{module}/{version}/`).
+
+| `redirect_generator.rb` | Post-write hook: copies data files to legacy paths (for XML parsers),
+                           generates HTML meta-refresh redirects for directory paths.
 |===
 
 
 == Package Manifest
 
-The package manifests (`lxr_packages.yml` for XSD, `json_packages.yml` for JSON) live in this repo.
-They provide human metadata (title, description, status). File paths and resources are
-auto-discovered from the filesystem by `generate_configs.rb`.
+The package manifests (`lxr_packages.yml` for XSD, `ljr_packages.yml` for JSON) live in
+the `schemas/` submodule. They provide human metadata (title, description, status).
+File paths and resources are auto-discovered from the filesystem by `generate_configs.rb`.

--- a/_pages/about.html
+++ b/_pages/about.html
@@ -78,19 +78,22 @@ permalink: /about/
       <h2 class="doc-section__title">Serving Schemas</h2>
       <p class="doc-section__desc">
         This site serves both XML and JSON schemas for direct machine
-        consumption:
+        consumption. All files are served at <strong>canonical top-level
+        URLs</strong> — there is no <code>/schemas/</code> prefix in any
+        URL path.
       </p>
       <ul class="resources-list">
         <li>
           <strong>XML Schemas (XSD)</strong> — served at their normative
-          <code>schemaLocation</code> URLs. Tools resolve these automatically
-          via <code>xsi:schemaLocation</code> or <code>&lt;import&gt;</code>
-          directives.
+          <code>schemaLocation</code> URLs:
+          <code>/{standard}/{part}/{module}/{version}/{module}.xsd</code>.
+          Tools resolve these automatically via <code>xsi:schemaLocation</code>
+          or <code>&lt;import&gt;</code> directives.
         </li>
         <li>
           <strong>JSON Schemas</strong> — served under
-          <code>/json/{standard}/…</code>. Use the <code>$id</code>
-          URI for <code>$ref</code> resolution.
+          <code>/json/{standard}/{part}/{module}/{version}/…</code>.
+          Use the <code>$id</code> URI for <code>$ref</code> resolution.
         </li>
         <li>
           <strong>Interactive Browsers</strong> — each schema package has a
@@ -99,9 +102,22 @@ permalink: /about/
         </li>
         <li>
           <strong>Namespace Hubs</strong> — each XML namespace resolves to a
-          hub page listing schema locations, package info, and browse links.
+          hub page at <code>/{standard}/{part}/{module}/{version}/</code>
+          listing schema locations, package info, and browse links.
+        </li>
+        <li>
+          <strong>Supporting resources</strong> — examples, transforms,
+          codelists, Schematron rules, and download bundles are served under
+          per-standard paths like <code>/{standard}/resources/…</code>.
         </li>
       </ul>
+      <p class="doc-section__desc" style="margin-top:0.75rem;">
+        Some schemas were previously available at different paths (e.g.,
+        without a part number, or with a <code>/schemas/</code> prefix).
+        These legacy paths are redirected to the canonical URLs above.
+        For XML data files, the actual file is served at the old path since
+        XML parsers cannot follow HTML redirects.
+      </p>
     </div>
 
     <div class="doc-section">

--- a/_posts/2026-05-05-schema-browser-redesign.md
+++ b/_posts/2026-05-05-schema-browser-redesign.md
@@ -30,39 +30,71 @@ The underlying [schemas repository](https://github.com/ISO-TC211/schemas)
 has been restructured with consistent directory naming (`standard/-part/module/version/`),
 separated examples, consolidated per-standard resources, and proper ZIP bundles.
 
-## Schema namespace patterns
+## URL structure
 
-### XML Schema (XSD) namespaces
+All schemas are served at **canonical top-level URLs** with no `/schemas/` prefix.
+This is the URL pattern that XML parsers, validators, and `schemaLocation` attributes
+rely on.
 
-XML schemas use the following namespace URI pattern:
+### XML namespaces
 
 ```
 https://schemas.isotc211.org/{standard}/{part}/{module}/{major}.{minor}
 ```
 
-For example:
 * `https://schemas.isotc211.org/19115/-1/cit/1.3` — ISO 19115-1 Citation module
 * `https://schemas.isotc211.org/19136/-/gml/1.0` — ISO 19136 GML
 * `https://schemas.isotc211.org/19157/-2/mdq/1.0` — ISO 19157-2 Data Quality measures
 
-Schema files are located at:
+### XML Schema files (XSD)
 
 ```
-https://schemas.isotc211.org/schemas/{standard}/{part}/{module}/{version}/{module}.xsd
+https://schemas.isotc211.org/{standard}/{part}/{module}/{version}/{module}.xsd
 ```
 
-### JSON Schema namespaces
+* `https://schemas.isotc211.org/19115/-1/cit/1.3.0/cit.xsd`
+* `https://schemas.isotc211.org/19136/-/gml/1.0/gml.xsd`
+* `https://schemas.isotc211.org/19139/-/gco/1.0/gco.xsd`
 
-JSON schemas follow the same organizational pattern:
+### JSON Schema files
 
 ```
-https://schemas.isotc211.org/schemas/json/{standard}/{part}/{module}/{version}/{module}.json
+https://schemas.isotc211.org/json/{standard}/{part}/{module}/{version}/{module}.json
 ```
 
-For example:
-* `json/19115/-4/mdj/1.0.0/mdj.json` — ISO 19115-4 Metadata JSON
-* `json/19123/-2/cis/1.2/coverage-schema.json` — ISO 19123-2 Coverage JSON
-* `json/19157/-1/dqc/1.0.0/dqc.json` — ISO 19157-1 Data Quality JSON
+* `https://schemas.isotc211.org/json/19115/-4/mdj/1.0.0/mdj.json`
+* `https://schemas.isotc211.org/json/19123/-2/cis/1.2/coverage-schema.json`
+* `https://schemas.isotc211.org/json/19157/-1/dqc/1.0.0/dqc.json`
+
+### Interactive schema browsers
+
+```
+https://schemas.isotc211.org/{standard}/{part}/{module}/{version}/browse/
+```
+
+### Namespace hub pages
+
+```
+https://schemas.isotc211.org/{standard}/{part}/{module}/{version}/
+```
+
+### Supporting resources
+
+```
+/{standard}/{part}/{module}/{version}/examples/...     — XML examples
+/json/{standard}/{part}/{module}/{version}/examples/... — JSON examples
+/{standard}/resources/transforms/...                    — XSLT transforms
+/{standard}/resources/codelists/...                     — Codelist dictionaries
+/{standard}/resources/bundles/...                       — Download packages
+```
+
+### Legacy paths
+
+Some schemas were previously available at different paths (e.g., without
+the part number, or with a `/schemas/` prefix). These old paths are
+redirected to the canonical URLs above. XML data files are served as
+actual file copies at the old path (since XML parsers cannot follow
+HTML redirects).
 
 ## Supported standards
 


### PR DESCRIPTION
Documents the canonical URL scheme and the 'no `/schemas/` prefix' rule across all four documentation surfaces.

### Changes
- **README.adoc** — Added full URL structure table with all resource patterns, path elements, and legacy redirect explanation
- **CLAUDE.md** — Added 'Canonical URL Rule' section, updated build commands, architecture, plugin docs, and deployment flow
- **Blog post** — Fixed incorrect `/schemas/` paths, replaced with correct canonical URL patterns and examples
- **About page** — Added explicit 'no `/schemas/` prefix' statement, expanded serving section

This ensures the canonical URL scheme is documented everywhere and won't be accidentally violated in the future.