### PR TITLE
ci: skip lutaml toolchain on cache hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,18 +42,6 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
-      - name: Setup Ruby (lutaml)
-        run: BUNDLE_GEMFILE=schemas/Gemfile BUNDLE_PATH=vendor/bundle-lutaml bundle install
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install Node dependencies
-        run: npm ci
-
       - name: Cache LXR/SPA build artifacts
         uses: actions/cache@v4
         id: lxr-cache
@@ -65,6 +53,21 @@ jobs:
             schemas_index.json
             resources_index.json
           key: lxr-v1-${{ hashFiles('generate_configs.rb', 'schemas/lxr_packages.yml', 'schemas/ljr_packages.yml', 'schemas/Gemfile.lock', 'Makefile') }}-${{ steps.cache-key.outputs.schemas_sha }}
+
+      - name: Setup Ruby (lutaml)
+        if: steps.lxr-cache.outputs.cache-hit != 'true'
+        run: BUNDLE_GEMFILE=schemas/Gemfile BUNDLE_PATH=vendor/bundle-lutaml bundle install
+
+      - name: Setup Node
+        if: steps.lxr-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        if: steps.lxr-cache.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Build lutaml-jsonschema frontend
         if: steps.lxr-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
When the LXR/SPA cache hits (doc-only changes), skip installing the lutaml Ruby bundle, Node.js, npm deps, and building the lutaml-jsonschema frontend.

Moves the LXR cache check before the toolchain setup steps and adds `if: cache-hit != 'true'` guards. On cache hit, build time drops from ~9 min to ~1 min (Jekyll build only).

### Before (cache hit)
1. Checkout + submodules ✓
2. Setup Ruby ✓  
3. Setup Ruby (lutaml) ← **unnecessary**
4. Setup Node ← **unnecessary**
5. npm ci ← **unnecessary**
6. Cache hit → skip build ✓
7. Jekyll build ✓

### After (cache hit)
1. Checkout + submodules ✓
2. Setup Ruby ✓
3. Cache hit → skip steps 4-7 ✓
4. Jekyll build ✓