### PR TITLE
fix: differentiate resource labels by standard part

### DIFF
--- a/_frontend/js/schemas.js
+++ b/_frontend/js/schemas.js
@@ -9,17 +9,9 @@ async function loadSchemas() {
   if (!container) return
 
   let schemas = []
-  let resourceMap = {}
   try {
-    const [schemaRes, resourceRes] = await Promise.all([
-      fetch('/schemas_index.json'),
-      fetch('/resources_index.json'),
-    ])
+    const schemaRes = await fetch('/schemas_index.json')
     schemas = await schemaRes.json()
-    const resourceData = await resourceRes.json()
-    if (resourceData.standards) {
-      resourceMap = resourceData.standards
-    }
   } catch {
     container.innerHTML = emptyState('Could not load schema index. Run <code>make all</code> to build.')
     return
@@ -39,7 +31,7 @@ async function loadSchemas() {
 
       visibleCount++
 
-      const resInfo = buildResourceChips(data.standard, resourceMap[data.standard])
+      const resInfo = buildResourceChipsFromPackages(data.packages)
 
       html += `
         <a href="/${esc(data.url)}/" class="std-card animate-fade-in-up" style="animation-delay: ${visibleCount * 30}ms">
@@ -76,9 +68,16 @@ async function loadSchemas() {
   render()
 }
 
-function buildResourceChips(standard, resources) {
-  if (!resources) return ''
-  const chips = []
+function buildResourceChipsFromPackages(packages) {
+  const aggregated = {}
+  for (const pkg of packages) {
+    const counts = pkg.resource_counts || {}
+    for (const [cat, count] of Object.entries(counts)) {
+      aggregated[cat] = (aggregated[cat] || 0) + count
+    }
+  }
+  if (Object.keys(aggregated).length === 0) return ''
+
   const labels = {
     transforms: { label: 'XSL', badge: 'badge--xslt' },
     schematron: { label: 'SCH', badge: 'badge--schematron' },
@@ -87,11 +86,11 @@ function buildResourceChips(standard, resources) {
     codelists: { label: 'CL', badge: 'badge--codelists' },
     bundles: { label: 'ZIP', badge: 'badge--bundles' },
   }
-  for (const [cat, files] of Object.entries(resources)) {
-    if (!files || files.length === 0) continue
+  const chips = []
+  for (const [cat, count] of Object.entries(aggregated)) {
     const info = labels[cat]
-    if (!info) continue
-    chips.push(`<span class="badge ${info.badge}">${files.length} ${info.label}</span>`)
+    if (!info || count === 0) continue
+    chips.push(`<span class="badge ${info.badge}">${count} ${info.label}</span>`)
   }
   return chips.join('')
 }

--- a/generate_configs.rb
+++ b/generate_configs.rb
@@ -286,12 +286,15 @@ module SchemaIndex
       if part_match
         return part_match[1] == pkg.part
       end
-      case pkg.type
-      when "json"
-        %w[examples_json codelists bundles].include?(category)
-      else
-        true
+      # Resources under standard/resources/ (no part segment) belong to XSD packages only
+      if path.start_with?("#{pkg.standard}/resources/")
+        return pkg.type == "xsd"
       end
+      # JSON examples under json/ directory
+      if path.start_with?("json/#{pkg.standard}/")
+        return pkg.type == "json"
+      end
+      false
     end
 
     private


### PR DESCRIPTION
## Problem

On the schemas.isotc211.org homepage, all parts of ISO 19115 showed identical resource badges (XSL, SCH, XML, JSON, etc.). In reality, only ISO 19115-4 has JSON schemas — the other parts were incorrectly inheriting the same labels.

## Root cause

`generate_configs.rb#resource_relevant?` matched resources by standard number alone, without considering the part. This caused all resources under `19115/` to be counted for every 19115-*/package regardless of which part they belonged to.

Additionally, `_frontend/js/schemas.js` consumed `resources_index.json` which groups resources at the standard level (not by part), making it impossible to display per-part labels correctly.

## Changes

- **`generate_configs.rb`** — Fixed `resource_relevant?` to match resources by part prefix:
  - Part-scoped resources (`json/{std}/{-part}/...`) match only when the part matches
  - Standard-level resources (`{std}/resources/...`) belong to XSD packages only
  - JSON examples match only JSON packages
  - Falls through to `false` instead of `true` for unmatched paths

- **`_frontend/js/schemas.js`** — Replaced `resources_index.json` consumption with per-package `resource_counts` from `schemas_index.json`. New `buildResourceChipsFromPackages()` aggregates counts from all packages in a standard group, giving correct per-part badges.

## Verification

- 19115-2 and 19115-3 now show only their own XSD/XSL/SCH resources
- 19115-4 shows its JSON schema badge (and no false XSD badges from other parts)
- Other standards with single parts are unaffected