### PR TITLE
fix: exclude XML resources from JSON-only standard detail pages

### DIFF
--- a/_plugins/schema_pages_generator.rb
+++ b/_plugins/schema_pages_generator.rb
@@ -64,7 +64,7 @@ module SchemaSite
           if part_match
             part_match[1] == part
           elsif has_only_json
-            %w[examples_json codelists bundles].include?(cat)
+            cat == "examples_json"
           else
             true
           end


### PR DESCRIPTION
## Problem

The standard detail page at `/19115/-4/` shows XML resources (27 codelist dictionaries, 41 download packages) that belong to 19115 parts -1/-2/-3, not part -4. Part -4 only has JSON schemas.

## Root cause

`filter_resources_for_part` in `_plugins/schema_pages_generator.rb` has an `elsif has_only_json` branch that allows `codelists` and `bundles` through for JSON-only standard pages. These resources live under `{standard}/resources/` (no part segment), so the part-based filter does not exclude them.

The original intent was to show non-part-specific resources on JSON pages, but codelists and bundles are XML-specific resources (XML codelist dictionaries, ZIP bundles of XSD files) that should not appear on JSON-only pages.

## Fix

Changed the `elsif has_only_json` condition from:
```ruby
%w[examples_json codelists bundles].include?(cat)
```
to:
```ruby
cat == "examples_json"
```

For JSON-only pages, resources without a part segment are now only included if they are `examples_json`.

## Verification

Simulated the filter for `/19115/-4/` (JSON-only, part=-4):

| Category | Before | After |
|---|---|---|
| transforms (19) | 0 ✓ | 0 ✓ |
| schematron (32) | 0 ✓ | 0 ✓ |
| examples_xml (47) | 0 ✓ | 0 ✓ |
| examples_json (1) | 1 ✓ | 1 ✓ |
| codelists (27) | **27** ✗ | 0 ✓ |
| bundles (41) | **41** ✗ | 0 ✓ |

XSD standard pages (e.g. `/19115/-1/`) are unaffected — they continue to show all XML resources correctly.