### PR TITLE
fix: correct resource assignment and update homepage for JSON schemas

### DIFF
--- a/_frontend/js/schemas.js
+++ b/_frontend/js/schemas.js
@@ -69,14 +69,16 @@ async function loadSchemas() {
 }
 
 function buildResourceChipsFromPackages(packages) {
-  const aggregated = {}
+  // Deduplicate: take the max count per category across packages
+  // instead of summing, since multiple packages may share the same resources
+  const deduped = {}
   for (const pkg of packages) {
     const counts = pkg.resource_counts || {}
     for (const [cat, count] of Object.entries(counts)) {
-      aggregated[cat] = (aggregated[cat] || 0) + count
+      deduped[cat] = Math.max(deduped[cat] || 0, count)
     }
   }
-  if (Object.keys(aggregated).length === 0) return ''
+  if (Object.keys(deduped).length === 0) return ''
 
   const labels = {
     transforms: { label: 'XSL', badge: 'badge--xslt' },
@@ -87,7 +89,7 @@ function buildResourceChipsFromPackages(packages) {
     bundles: { label: 'ZIP', badge: 'badge--bundles' },
   }
   const chips = []
-  for (const [cat, count] of Object.entries(aggregated)) {
+  for (const [cat, count] of Object.entries(deduped)) {
     const info = labels[cat]
     if (!info || count === 0) continue
     chips.push(`<span class="badge ${info.badge}">${count} ${info.label}</span>`)

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,9 +13,13 @@
   <link rel="manifest" href="{{ '/assets/site.webmanifest' | relative_url }}" />
   <meta name="theme-color" content="#0061ad" />
 
+  <script>;(function(){try{var s=localStorage.getItem('iso-tc211-theme');if(s==='dark'||(!s&&window.matchMedia('(prefers-color-scheme:dark)').matches))document.documentElement.classList.add('dark')}catch(e){}})();</script>
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Noto+Sans+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+  {% vite_javascript_tag application %}
 
   <style>
     html{scroll-behavior:smooth!important}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}" class="">
+
+{% include head.html %}
+
+<body class="bg-white dark:bg-slate-900 text-slate-900 dark:text-white antialiased">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  {% include header.html %}
+
+  <main id="main-content">
+    {{ content }}
+  </main>
+
+  {% include footer.html %}
+</body>
+</html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,5 @@
+---
+layout: base
+---
+
+{{ content }}

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -1,6 +1,6 @@
 ---
 layout: home
-title: XML Schemas
+title: Schemas
 permalink: /
 ---
 
@@ -11,17 +11,21 @@ permalink: /
       <span class="dot"></span>
       ISO/TC 211 Schemas
     </div>
-    <h1 class="hero-section__title">XML Schema Repository</h1>
+    <h1 class="hero-section__title">Schema Repository</h1>
     <p class="hero-section__desc">
-      The authoritative repository of XML schema representations for
+      The authoritative repository of XML and JSON schema representations for
       <a href="https://committee.iso.org/home/tc211">ISO/TC&nbsp;211</a>
       Geographic information/Geomatics standards.
-      Browse interactive documentation for each schema, or download the XSD files directly.
+      Browse interactive documentation for each schema, or download the files directly.
     </p>
     <div class="url-box">
       <div class="url-box__item--dark url-box__item">
-        <p class="url-box__label">Schema location URL pattern</p>
+        <p class="url-box__label">XML Schema location URL pattern</p>
         <code>https://schemas.isotc211.org/<span class="dim">{Standard}</span>/<span class="dim">{Part}</span>/<span class="dim">{Prefix}</span>/<span class="dim">{Version}</span></code>
+      </div>
+      <div class="url-box__item--dark url-box__item">
+        <p class="url-box__label">JSON Schema location URL pattern</p>
+        <code>https://schemas.isotc211.org/json/<span class="dim">{Standard}</span>/<span class="dim">{Part}</span>/<span class="dim">{Module}</span>/<span class="dim">{Version}</span></code>
       </div>
     </div>
   </div>

--- a/_plugins/schema_pages_generator.rb
+++ b/_plugins/schema_pages_generator.rb
@@ -62,7 +62,7 @@ module SchemaSite
           path = f["path"]
           part_match = path.match(%r{\A(?:json/)?#{Regexp.escape(standard)}/(-\d+)/})
           if part_match
-            part_match[1] == part
+            part_match[1] == part && (has_only_json ? cat == "examples_json" : true)
           elsif has_only_json
             cat == "examples_json"
           else

--- a/generate_configs.rb
+++ b/generate_configs.rb
@@ -284,17 +284,14 @@ module SchemaIndex
     def resource_relevant?(path, category, pkg)
       part_match = path.match(%r{\A(?:json/)?#{Regexp.escape(pkg.standard)}/(-\d+)/})
       if part_match
-        return part_match[1] == pkg.part
+        return false unless part_match[1] == pkg.part
       end
-      # Resources under standard/resources/ (no part segment) belong to XSD packages only
-      if path.start_with?("#{pkg.standard}/resources/")
-        return pkg.type == "xsd"
-      end
-      # JSON examples under json/ directory
-      if path.start_with?("json/#{pkg.standard}/")
+      # JSON examples belong only to JSON packages
+      if category == "examples_json"
         return pkg.type == "json"
       end
-      false
+      # All other resource categories are XML-only
+      return pkg.type == "xsd"
     end
 
     private


### PR DESCRIPTION
## Problem

Three categories of issues:

### 1. Resource assignment bugs
After the JSON schema packages (19115-4, 19157-1, 19123-2) were added, resource display was incorrect:
- Schematron/XML resources leaked onto JSON-only pages (`/19157/-1/` showed Schematron rules)
- Wrong resource categories assigned to JSON packages (`19123-2-cis-json-1.2` showed 14 Schematron + 26 XML examples)
- Homepage resource counts inflated by summing across packages sharing the same resources

### 2. Homepage content outdated
- Title said "XML Schema Repository" — site now hosts JSON schemas too
- Description mentioned only XML schemas
- No JSON Schema URL pattern shown

### 3. Flash on page load
The Vite CSS bundle loaded at the bottom of `<body>` because `vite_javascript_tag` outputs both `<script>` and `<link>` together, and the theme placed it at body end. Meanwhile `vite_stylesheet_tag` in `<head>` produced nothing (CSS was bundled through JS entrypoint).

This caused:
- **FOUC**: Page painted with only 6 lines of inline critical CSS, then all styles snapped in
- **Dark mode flash**: `theme.js` ran after first paint — dark-mode users saw white→dark switch
- **Empty cards**: Homepage `#schema-groups` was empty until JS fetched JSON and rendered cards

## Changes

### `generate_configs.rb` — Resource type categorization
Rewrote `resource_relevant?` to use category-based logic:
- `examples_json` → only assigned to JSON packages
- All other categories → only assigned to XSD packages

### `schema_pages_generator.rb` — Standard page resource filtering
`filter_resources_for_part` now applies the JSON-only guard consistently for resources with part segments.

### `schemas.js` — Homepage resource chip deduplication
Uses `Math.max` per category instead of summing.

### `_pages/index.html` — Homepage content update
- Title: "XML Schema Repository" → "Schema Repository"
- Description mentions both XML and JSON schemas
- Added JSON Schema URL pattern box

### `_layouts/base.html` + `_layouts/default.html` — Layout overrides
- Override theme layout chain to control where Vite assets are placed
- `base.html`: full HTML document WITHOUT `vite_javascript_tag` at body end
- `default.html`: inherits from `base`, just renders content

### `_includes/head.html` — Assets in head + dark mode script
- Moves `{% vite_javascript_tag application %}` into `<head>`
  - `<script type="module">` is automatically deferred (does not block parsing)
  - `<link rel="stylesheet">` in `<head>` blocks rendering (prevents FOUC)
- Adds inline dark mode detection script that runs synchronously before paint
  - Checks `localStorage` and `prefers-color-scheme`
  - Adds `dark` class to `<html>` before first paint
  - Eliminates light→dark flash for dark-mode users

## Before/After

| Issue | Before | After |
|---|---|---|
| CSS loading | At bottom of `<body>` → FOUC | In `<head>` → blocks rendering |
| Dark mode | Flash white→dark (JS runs late) | Instant (inline script in head) |
| JSON pages | Showed Schematron/XML resources | Only JSON examples |
| Homepage counts | Inflated (summed) | Correct (deduped via Math.max) |
| Homepage text | "XML Schema Repository" | "Schema Repository" with JSON URL pattern |