### PR TITLE
fix: replace schemas git submodule with actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,19 +21,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
+      - name: Checkout site
+        uses: actions/checkout@v6
 
-      - name: Update schemas to latest
-        if: github.event_name == 'repository_dispatch'
-        run: git submodule update --remote schemas
+      - name: Checkout schemas
+        uses: actions/checkout@v6
+        with:
+          repository: ISO-TC211/schemas
+          path: schemas
 
       - name: Compute build cache key
         id: cache-key
         run: |
-          SCHEMAS_SHA=$(git submodule status schemas | awk '{print $1}')
+          SCHEMAS_SHA=$(git -C schemas rev-parse HEAD)
           echo "schemas_sha=${SCHEMAS_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Ruby

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "schemas"]
-	path = schemas
-	url = https://github.com/ISO-TC211/schemas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Architecture: **1 standard+part+version → 1 LXR package → 1 SPA HTML file**,
 | Schema browser | `/{standard}/{part}/{module}/{version}/browse/` |
 | Namespace hub | `/{standard}/{part}/{module}/{version}/` |
 
-The `schemas/` directory is a git submodule (source files). The `BuildSourceGenerator` plugin registers files from `schemas/` as Jekyll static files, and Jekyll serves them at top-level paths (stripping the `schemas/` base dir). Never add `/schemas/` to any URL path.
+The `schemas/` directory is cloned from ISO-TC211/schemas via CI (`actions/checkout`). The `BuildSourceGenerator` plugin registers files from `schemas/` as Jekyll static files, and Jekyll serves them at top-level paths (stripping the `schemas/` base dir). Never add `/schemas/` to any URL path.
 
 The `url_path()` helper in `models.rb` strips the `schemas/` prefix from paths stored in `schemas_index.json` (which reference the source directory).
 
@@ -32,7 +32,7 @@ The `url_path()` helper in `models.rb` strips the `schemas/` prefix from paths s
 
 `lutaml-xsd` depends on `terminal-table` in a way incompatible with Jekyll ~> 4.3. They cannot share a single Gemfile:
 - **`Gemfile`** (site repo) — Jekyll + jekyll-theme-isotc211 + jekyll-vite (for `bundle exec jekyll build/serve`)
-- **`schemas/Gemfile`** (submodule) — lutaml-xsd + lutaml-model + lutaml-jsonschema (for lutaml commands)
+- **`schemas/Gemfile`** (cloned repo) — lutaml-xsd + lutaml-model + lutaml-jsonschema (for lutaml commands)
 
 The lutaml bundle uses a separate install path (`vendor/bundle-lutaml`) to avoid corrupting the Jekyll bundle. The Makefile uses `BUNDLE_GEMFILE=schemas/Gemfile BUNDLE_PATH=vendor/bundle-lutaml` for all lutaml commands.
 
@@ -62,14 +62,14 @@ make serve
 # Clean all build artifacts
 make clean
 
-# Update git submodules (schemas)
+# Update schemas (clone or pull latest)
 make update
 ```
 
 ## Architecture
 
 ```
-schemas/              → Git submodule (ISO-TC211/schemas), MECE directory structure:
+schemas/              → Cloned from ISO-TC211/schemas, MECE directory structure:
                         {standard}/{-part}/{module}/{version}/*.xsd
                         {standard}/resources/{transforms,codelists,schematron,bundles}/
                         json/{standard}/{-part}/{module}/{version}/*.json
@@ -119,7 +119,7 @@ Gemfile               → Site deps: Jekyll + jekyll-theme-isotc211 + jekyll-vit
 Makefile              → Build orchestration
 ```
 
-## Directory Naming Convention (schemas/ submodule)
+## Directory Naming Convention (schemas/ directory)
 
 All paths follow `standard/-part/module/version/`:
 - **Standard**: 5 digits (e.g., `19115`)
@@ -169,7 +169,7 @@ Defined in `generate_configs.rb`, auto-included in every lutaml-xsd config:
 
 ## Deployment
 
-GitHub Actions workflow (`.github/workflows/ci.yml`) builds on push to `main` and deploys `_site/` to GitHub Pages. The schemas submodule (ISO-TC211/schemas) triggers a `repository_dispatch` event to rebuild the site on schema changes.
+GitHub Actions workflow (`.github/workflows/ci.yml`) builds on push to `main` and deploys `_site/` to GitHub Pages. The schemas repo (ISO-TC211/schemas) triggers a `repository_dispatch` event to rebuild the site on schema changes.
 
 ### Build pipeline
 1. `make configs` — `generate_configs.rb` produces per-package configs + `Makefile.spa` (with `SPA_FILES` list)

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,6 @@ clean:
 	rm -rf build site _site configs schemas_index.json resources_index.json
 
 update:
-	git submodule update --init
-	git submodule foreach git checkout main
-	git submodule foreach git pull origin main
+	git -C schemas pull || git clone --depth 1 https://github.com/ISO-TC211/schemas.git schemas
 
 .PHONY: all configs lxr-spas clean serve update

--- a/generate_configs.rb
+++ b/generate_configs.rb
@@ -349,7 +349,7 @@ module SchemaIndex
     def load_manifest(filename, klass)
       path = File.join(@schemas_dir, filename)
       unless File.exist?(path)
-        raise "Manifest #{filename} not found in schemas/ — it must be defined in the schemas submodule"
+        raise "Manifest #{filename} not found in schemas/ — it must be defined in the schemas directory"
       end
 
       manifest = YAML.load_file(path)


### PR DESCRIPTION
The git submodule caused repeated sync failures: pushes to the site repo (e.g. CSS fixes) would build from the pinned submodule SHA instead of the latest schemas main, regressing deployed schema content.

Now the CI checks out the schemas repo independently via actions/checkout@v6 at the latest main on every build, regardless of trigger type.

Changes:
- Remove .gitmodules and schemas submodule entry
- CI: checkout site and schemas as separate steps (actions/checkout@v6)
- CI: compute cache key from cloned schemas SHA (git rev-parse)
- Makefile: update target uses git pull/clone instead of submodule commands
- CLAUDE.md: update all submodule references