### PR TITLE
feat: use ISO branding in schema browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,13 +67,59 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
-      - name: Build lutaml-jsonschema frontend
+      - name: Patch lutaml frontends with ISO branding
         if: steps.lxr-cache.outputs.cache-hit != 'true'
         run: |
-          GEM_DIR=$(BUNDLE_GEMFILE=schemas/Gemfile BUNDLE_PATH=vendor/bundle-lutaml bundle show lutaml-jsonschema)
-          cd "$GEM_DIR/frontend"
-          npm install
-          npm run build
+          ISO_LOGO="https://www.isotc211.org/assets/iso-red.svg"
+          LUTAML_LIGHT="https://raw.githubusercontent.com/lutaml/branding/refs/heads/main/svg/lutaml-logo_logo-icon-light.svg"
+          LUTAML_DARK="https://raw.githubusercontent.com/lutaml/branding/refs/heads/main/svg/lutaml-logo_logo-icon-dark.svg"
+          LUTAML_FOOTER_LIGHT="https://raw.githubusercontent.com/lutaml/branding/refs/heads/main/svg/lutaml-logo_logo-full-light.svg"
+          LUTAML_FOOTER_DARK="https://raw.githubusercontent.com/lutaml/branding/refs/heads/main/svg/lutaml-logo_logo-full-dark.svg"
+
+          for gem_name in lutaml-jsonschema lutaml-xsd; do
+            GEM_DIR=$(BUNDLE_GEMFILE=schemas/Gemfile BUNDLE_PATH=vendor/bundle-lutaml bundle show "$gem_name" 2>/dev/null) || continue
+            SIDEBAR="$GEM_DIR/frontend/src/components/AppSidebar.vue"
+            [ -f "$SIDEBAR" ] || continue
+
+            # Replace sidebar branding logo (both icon and fallback)
+            sed -i "s|${LUTAML_LIGHT}|${ISO_LOGO}|g" "$SIDEBAR"
+            sed -i "s|${LUTAML_DARK}|${ISO_LOGO}|g" "$SIDEBAR"
+            sed -i "s|${LUTAML_FOOTER_LIGHT}|${ISO_LOGO}|g" "$SIDEBAR"
+            sed -i "s|${LUTAML_FOOTER_DARK}|${ISO_LOGO}|g" "$SIDEBAR"
+
+            # Replace branding alt text
+            sed -i 's/alt="LutaML"/alt="ISO"/g' "$SIDEBAR"
+
+            # Replace subtitle text
+            sed -i 's/LutaML JSON Schema/ISO\/TC 211 Schemas/g' "$SIDEBAR"
+            sed -i 's/LXR Package/ISO\/TC 211 Schemas/g' "$SIDEBAR"
+
+            # Replace footer link
+            sed -i 's|href="https://www.lutaml.org"|href="https://isotc211.org"|g' "$SIDEBAR"
+            sed -i 's/title="LutaML"/title="ISO\/TC 211"/g' "$SIDEBAR"
+
+            # Replace "Generated with LutaML ..." text
+            sed -i 's|Generated on|Built on|g' "$SIDEBAR"
+            sed -i 's|with\s*$|with|g' "$SIDEBAR"
+            sed -i 's|<a href="https://github.com/lutaml/lutaml-jsonschema"|<a href="https://schemas.isotc211.org"|g' "$SIDEBAR"
+            sed -i 's|<a href="https://github.com/lutaml/lutaml-xsd"|<a href="https://schemas.isotc211.org"|g' "$SIDEBAR"
+            sed -i 's|>LutaML JSON Schema</a>|>ISO\/TC 211 Schema Browser</a>|g' "$SIDEBAR"
+            sed -i 's|>LutaML XSD</a>|>ISO\/TC 211 Schema Browser</a>|g' "$SIDEBAR"
+
+            echo "Patched $gem_name branding"
+          done
+
+      - name: Build lutaml frontends
+        if: steps.lxr-cache.outputs.cache-hit != 'true'
+        run: |
+          for gem_name in lutaml-jsonschema lutaml-xsd; do
+            GEM_DIR=$(BUNDLE_GEMFILE=schemas/Gemfile BUNDLE_PATH=vendor/bundle-lutaml bundle show "$gem_name" 2>/dev/null) || continue
+            [ -d "$GEM_DIR/frontend" ] || continue
+            cd "$GEM_DIR/frontend"
+            npm install
+            npm run build
+            cd -
+          done
 
       - name: Build LXR packages and SPAs
         if: steps.lxr-cache.outputs.cache-hit != 'true'

--- a/generate_configs.rb
+++ b/generate_configs.rb
@@ -54,11 +54,25 @@ module SchemaIndex
     { "prefix" => "xlink", "uri" => "http://www.w3.org/1999/xlink" },
   ].freeze
 
+  ISO_LOGO_URL = "https://www.isotc211.org/assets/iso-red.svg"
+
   APPEARANCE = {
     "logos" => {
+      "square" => {
+        "light" => { "url" => ISO_LOGO_URL },
+        "dark" => { "url" => ISO_LOGO_URL },
+      },
+      "long" => {
+        "light" => { "url" => ISO_LOGO_URL },
+        "dark" => { "url" => ISO_LOGO_URL },
+      },
+      "icon" => {
+        "light" => { "url" => ISO_LOGO_URL },
+        "dark" => { "url" => ISO_LOGO_URL },
+      },
       "lutaml_logo" => {
-        "light" => { "url" => "https://raw.githubusercontent.com/lutaml/branding/main/svg/lutaml-logo_logo-full-light.svg" },
-        "dark" => { "url" => "https://raw.githubusercontent.com/lutaml/branding/main/svg/lutaml-logo_logo-full-dark.svg" },
+        "light" => { "url" => ISO_LOGO_URL },
+        "dark" => { "url" => ISO_LOGO_URL },
       },
     },
     "colors" => {
@@ -200,7 +214,7 @@ module SchemaIndex
         "links" => [
           { "name" => "Homepage", "url" => "https://schemas.isotc211.org" },
           { "name" => "Repository", "url" => "https://github.com/ISO-TC211/schemas-isotc211.github.io" },
-          { "name" => "Get Started with LutaML XSD", "url" => "https://lutaml.github.io/lutaml-xsd/getting-started" },
+          { "name" => "ISO/TC 211", "url" => "https://isotc211.org" },
         ],
       }
     end


### PR DESCRIPTION
Replace LutaML logos and branding text with ISO/TC 211 identity in all schema browser SPAs (both XSD/LXR and JSON/LJR).

Changes:
- Update APPEARANCE config with ISO logo URLs for all logo slots (square, long, icon, lutaml_logo)
- Add CI step to patch lutaml frontends before building (sidebar logo, subtitle, footer)
- Replace 'LutaML JSON Schema'/'LXR Package' with 'ISO/TC 211 Schemas'
- Build both lutaml-xsd and lutaml-jsonschema frontends in CI
- Companion PR: ISO-TC211/schemas (lxr_build_template.yml + CI patching)