### PR TITLE
feat: add codelist browse pages and persistent URL support

### DIFF
--- a/_data/redirects.yml
+++ b/_data/redirects.yml
@@ -91,3 +91,7 @@
   to: /19155/resources/bundles/19155.zip
 - from: /19157/19157.zip
   to: /19157/resources/bundles/19157.zip
+
+# Codelist persistent URL — old path redirect
+- from: /Resources/codelists.xml
+  to: /resources/codelists/codelists.xml

--- a/_frontend/css/schemas.css
+++ b/_frontend/css/schemas.css
@@ -1443,3 +1443,163 @@
     .animate-fade-in-up { animation: none; opacity: 1; }
   }
 }
+
+  /* ── Codelist Pages ── */
+  .cl-uri-box {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: #f0fdfa;
+    border: 1px solid #99f6e4;
+    border-radius: 0.5rem;
+    margin-bottom: 1.5rem;
+    max-width: 48rem;
+  }
+  .dark .cl-uri-box {
+    background: #042f2e;
+    border-color: #115e59;
+  }
+  .cl-uri-box__label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #0d9488;
+    white-space: nowrap;
+  }
+  .dark .cl-uri-box__label { color: #5eead4; }
+  .cl-uri-box__value {
+    font-size: 0.8125rem;
+    color: #334155;
+    word-break: break-all;
+  }
+  .cl-uri-box__value em {
+    font-style: italic;
+    color: #64748b;
+  }
+  .dark .cl-uri-box__value { color: #cbd5e1; }
+  .dark .cl-uri-box__value em { color: #94a3b8; }
+
+  .cl-table-wrap {
+    overflow-x: auto;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.75rem;
+    background: #fff;
+  }
+  .dark .cl-table-wrap {
+    border-color: #334155;
+    background: #1e293b;
+  }
+  .cl-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+  }
+  .cl-table thead {
+    background: #f8fafc;
+    border-bottom: 2px solid #e2e8f0;
+  }
+  .dark .cl-table thead {
+    background: #0f172a;
+    border-bottom-color: #334155;
+  }
+  .cl-table th {
+    padding: 0.625rem 1rem;
+    text-align: left;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #64748b;
+  }
+  .dark .cl-table th { color: #94a3b8; }
+  .cl-row { border-bottom: 1px solid #f1f5f9; }
+  .dark .cl-row { border-bottom-color: #0f172a; }
+  .cl-row:last-child { border-bottom: none; }
+  .cl-row:hover { background: #f8fafc; }
+  .dark .cl-row:hover { background: #0f172a; }
+  .cl-row td { padding: 0.5rem 1rem; }
+  .cl-row__name a {
+    color: #0061ad;
+    font-weight: 500;
+    text-decoration: none;
+  }
+  .cl-row__name a:hover { text-decoration: underline; }
+  .dark .cl-row__name a { color: #66a3e0; }
+  .cl-row__id code,
+  .cl-row__name code {
+    font-size: 0.75rem;
+    background: #f1f5f9;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    color: #475569;
+  }
+  .dark .cl-row__id code,
+  .dark .cl-row__name code {
+    background: #0f172a;
+    color: #94a3b8;
+  }
+  .cl-row__desc {
+    color: #64748b;
+    max-width: 24rem;
+  }
+  .dark .cl-row__desc { color: #94a3b8; }
+  .cl-row__count {
+    text-align: center;
+    font-weight: 600;
+    color: #334155;
+  }
+  .dark .cl-row__count { color: #e2e8f0; }
+
+  .cl-breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8125rem;
+    color: #64748b;
+    margin-bottom: 1rem;
+  }
+  .dark .cl-breadcrumb { color: #94a3b8; }
+  .cl-breadcrumb a {
+    color: #0061ad;
+    text-decoration: none;
+  }
+  .cl-breadcrumb a:hover { text-decoration: underline; }
+  .dark .cl-breadcrumb a { color: #66a3e0; }
+  .cl-breadcrumb__sep { color: #cbd5e1; }
+  .dark .cl-breadcrumb__sep { color: #475569; }
+
+  .cl-detail {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem 1rem;
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+    font-size: 0.8125rem;
+  }
+  .dark .cl-detail {
+    background: #0f172a;
+    border-color: #334155;
+  }
+  .cl-detail dt {
+    font-weight: 600;
+    color: #334155;
+  }
+  .dark .cl-detail dt { color: #e2e8f0; }
+  .cl-detail dd { color: #475569; }
+  .dark .cl-detail dd { color: #94a3b8; }
+  .cl-detail__id {
+    font-size: 0.8125rem;
+    background: #f1f5f9;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+  }
+  .dark .cl-detail__id { background: #1e293b; }
+  .cl-detail__uri code {
+    font-size: 0.75rem;
+    word-break: break-all;
+  }

--- a/_plugins/codelist_pages_generator.rb
+++ b/_plugins/codelist_pages_generator.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require "rexml/document"
+require_relative "schema_site/models"
+
+module SchemaSite
+  class CodelistPagesGenerator < Jekyll::Generator
+    safe true
+    priority :low
+
+    CODELIST_XML = "schemas/resources/codelists/codelists.xml"
+
+    def generate(site)
+      xml_path = File.join(site.source, CODELIST_XML)
+      return unless File.exist?(xml_path)
+
+      catalogue = parse_catalogue(xml_path)
+      return if catalogue.empty?
+
+      site.pages << CodelistIndexPage.new(site, catalogue)
+      catalogue.each { |cl| site.pages << CodelistDetailPage.new(site, cl) }
+
+      puts "CodelistPages: #{catalogue.size} codelist pages"
+    end
+
+    private
+
+    def parse_catalogue(xml_path)
+      doc = REXML::Document.new(File.read(xml_path))
+      root = doc.root
+      return [] unless root
+
+      collect_codelists(root)
+    end
+
+    def collect_codelists(element)
+      result = []
+      element.elements.each("cat:codelistItem/cat:CT_Codelist") do |cl|
+        entry = build_codelist_entry(cl)
+        result << entry if entry
+      end
+      element.elements.each("cat:subCatalogue/cat:CT_CodelistCatalogue") do |sub|
+        result.concat(collect_codelists(sub))
+      end
+      result
+    end
+
+    def build_codelist_entry(cl)
+      id = cl.attributes["id"]
+      return nil unless id
+
+      {
+        "id" => id,
+        "name" => scoped_text(cl, "name") || id,
+        "identifier" => scoped_text(cl, "identifier") || id,
+        "definition" => char_text(cl, "definition"),
+        "description" => char_text(cl, "description"),
+        "values" => extract_values(cl),
+      }
+    end
+
+    def extract_values(cl)
+      result = []
+      cl.elements.each("cat:codeEntry/cat:CT_CodelistValue") do |entry|
+        entry_id = entry.attributes["id"]
+        next unless entry_id
+        result << {
+          "id" => entry_id,
+          "identifier" => scoped_text(entry, "identifier") || entry_id,
+          "name" => scoped_text(entry, "name"),
+          "definition" => char_text(entry, "definition"),
+          "description" => char_text(entry, "description"),
+        }
+      end
+      result
+    end
+
+    def scoped_text(element, child)
+      element.elements["cat:#{child}/gco:ScopedName"]&.text
+    end
+
+    def char_text(element, child)
+      element.elements["cat:#{child}/gco:CharacterString"]&.text
+    end
+  end
+
+  class CodelistIndexPage < Jekyll::PageWithoutAFile
+    include HtmlHelper
+
+    def initialize(site, codelists)
+      @site = site
+      @base = site.source
+      @dir = "resources/codelists"
+      @name = "index.html"
+
+      process(@name)
+      self.data = {
+        "layout" => "default",
+        "title" => "ISO/TC 211 Codelist Catalogues",
+      }
+      self.content = "{% raw %}\n#{build_content(codelists)}\n{% endraw %}"
+    end
+
+    private
+
+    def build_content(codelists)
+      rows = codelists.map do |cl|
+        desc = cl["description"] || cl["definition"] || ""
+        slug = cl["id"].tr("_", "-")
+        <<~HTML.chomp
+          <tr class="cl-row">
+            <td class="cl-row__name"><a href="/resources/codelists/#{esc(slug)}/">#{esc(cl['name'])}</a></td>
+            <td class="cl-row__id"><code>#{esc(cl['id'])}</code></td>
+            <td class="cl-row__desc">#{esc(truncate(desc, 80))}</td>
+            <td class="cl-row__count">#{cl['values']&.size || 0}</td>
+          </tr>
+        HTML
+      end.join("\n")
+
+      <<~HTML
+        <section class="page-section">
+          <div class="page-section__inner">
+            <h1 class="page-section__title">ISO/TC 211 Codelist Catalogues</h1>
+            <p class="page-section__desc">
+              Canonical codelist definitions for all ISO/TC 211 standards.
+              Source: <a href="/resources/codelists/codelists.xml">codelists.xml</a>
+            </p>
+            <div class="cl-uri-box">
+              <span class="cl-uri-box__label">Canonical URL pattern</span>
+              <code class="cl-uri-box__value">https://schemas.isotc211.org/resources/codelists/codelists.xml#<em>{CodelistId}</em></code>
+            </div>
+            <div class="cl-table-wrap">
+              <table class="cl-table">
+                <thead>
+                  <tr>
+                    <th>Codelist</th>
+                    <th>Identifier</th>
+                    <th>Description</th>
+                    <th>Values</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  #{rows}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      HTML
+    end
+
+    def truncate(str, max)
+      str.length > max ? "#{str[0..(max - 3)]}..." : str
+    end
+  end
+
+  class CodelistDetailPage < Jekyll::PageWithoutAFile
+    include HtmlHelper
+
+    def initialize(site, codelist)
+      slug = codelist["id"].tr("_", "-")
+      @site = site
+      @base = site.source
+      @dir = "resources/codelists/#{slug}"
+      @name = "index.html"
+
+      process(@name)
+      self.data = {
+        "layout" => "default",
+        "title" => codelist["name"],
+      }
+      self.content = "{% raw %}\n#{build_content(codelist)}\n{% endraw %}"
+    end
+
+    private
+
+    def build_content(cl)
+      rows = (cl["values"] || []).map do |v|
+        desc = v["description"] || v["definition"] || ""
+        <<~HTML.chomp
+          <tr class="cl-row">
+            <td class="cl-row__name"><code>#{esc(v['identifier'])}</code></td>
+            <td class="cl-row__desc">#{esc(truncate(desc, 120))}</td>
+            <td class="cl-row__id"><code>#{esc(v['id'])}</code></td>
+          </tr>
+        HTML
+      end.join("\n")
+
+      definition_html = cl["definition"] ? "<dt>Definition</dt><dd>#{esc(cl['definition'])}</dd>" : ""
+      description_html = cl["description"] && cl["description"] != cl["definition"] ? "<dt>Description</dt><dd>#{esc(cl['description'])}</dd>" : ""
+
+      <<~HTML
+        <section class="page-section">
+          <div class="page-section__inner">
+            <div class="cl-breadcrumb">
+              <a href="/resources/codelists/">Codelist Catalogues</a>
+              <span class="cl-breadcrumb__sep">&rsaquo;</span>
+              <span>#{esc(cl['name'])}</span>
+            </div>
+            <h1 class="page-section__title">#{esc(cl['name'])}</h1>
+            <dl class="cl-detail">
+              <dt>Identifier</dt>
+              <dd><code class="cl-detail__id">#{esc(cl['id'])}</code></dd>
+              #{definition_html}
+              #{description_html}
+              <dt>Canonical URI</dt>
+              <dd class="cl-detail__uri">
+                <code>https://schemas.isotc211.org/resources/codelists/codelists.xml##{esc(cl['id'])}</code>
+              </dd>
+              <dt>Defined values</dt>
+              <dd>#{cl['values']&.size || 0} codes</dd>
+            </dl>
+            <div class="cl-table-wrap">
+              <table class="cl-table">
+                <thead>
+                  <tr>
+                    <th>Value</th>
+                    <th>Description</th>
+                    <th>Fragment ID</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  #{rows}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      HTML
+    end
+
+    def truncate(str, max)
+      str.length > max ? "#{str[0..(max - 3)]}..." : str
+    end
+  end
+end

--- a/_plugins/schema_site/models.rb
+++ b/_plugins/schema_site/models.rb
@@ -13,7 +13,8 @@ module SchemaSite
     "examples_json" => { label: "JSON Examples",         color: "blue",   icon_svg: '<path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"/>' },
     "codelists"     => { label: "Codelist Dictionaries", color: "teal",   icon_svg: '<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 12h.007v.008H3.75V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm-.375 5.25h.007v.008H3.75v-.008zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"/>' },
     "bundles"       => { label: "Download Packages",     color: "green",  icon_svg: '<path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"/>' },
-  }.freeze
+
+    "general_codelists" => { label: "General Codelist Catalogues", color: "teal",   icon_svg: '<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 12h.007v.008H3.75V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm-.375 5.25h.007v.008H3.75v-.008zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"/>' },  }.freeze
 
   module HtmlHelper
     def esc(str)

--- a/generate_configs.rb
+++ b/generate_configs.rb
@@ -97,6 +97,8 @@ module SchemaIndex
     "examples_json"=> { glob: "**/examples/*.json",                label: "JSON Examples" },
     "codelists"    => { glob: "*/resources/codelists/**/*.xml",    label: "Codelist Dictionaries" },
     "bundles"      => { glob: "*/resources/bundles/**/*.zip",      label: "Download Packages" },
+
+    "general_codelists" => { glob: "resources/codelists/**/*.xml", label: "General Codelist Catalogues" },
   }.freeze
 
   # ── Package base class ──
@@ -269,18 +271,30 @@ module SchemaIndex
       end
     end
 
+    CROSS_CUTTING_CATEGORIES = %w[general_codelists].freeze
+
     def scan_by_standard(packages)
       standards = packages.map { |p| p.standard }.uniq.sort
       resources = scan
 
-      standards.each_with_object({}) do |std, result|
+      result = standards.each_with_object({}) do |std, acc|
         std_resources = {}
         resources.each do |category, files|
+          next if CROSS_CUTTING_CATEGORIES.include?(category)
           matching = files.select { |f| f["path"].start_with?("#{std}/") || f["path"].start_with?("json/#{std}/") }
           std_resources[category] = matching unless matching.empty?
         end
-        result[std] = std_resources unless std_resources.empty?
+        acc[std] = std_resources unless std_resources.empty?
       end
+
+      cross_cutting = {}
+      resources.each do |category, files|
+        next unless CROSS_CUTTING_CATEGORIES.include?(category)
+        cross_cutting[category] = files unless files.empty?
+      end
+      result["_shared"] = cross_cutting unless cross_cutting.empty?
+
+      result
     end
 
     def compute_resource_counts(packages)
@@ -297,6 +311,7 @@ module SchemaIndex
     end
 
     def resource_relevant?(path, category, pkg)
+      return false if CROSS_CUTTING_CATEGORIES.include?(category)
       part_match = path.match(%r{\A(?:json/)?#{Regexp.escape(pkg.standard)}/(-\d+)/})
       if part_match
         return false unless part_match[1] == pkg.part


### PR DESCRIPTION
Adds interactive HTML codelist pages and persistent URL infrastructure for ISO/TC 211 codelist definitions.

**Changes:**
- `CodelistPagesGenerator` — new Jekyll generator that parses `codelists.xml` via REXML and generates an index page + 70 per-codelist detail pages at `/resources/codelists/{id}/`
- `general_codelists` resource category — cleanly separates cross-cutting resources from per-standard ones in the resource scanner (OCP)
- File-copy redirect for `/Resources/codelists.xml` — existing `codeList` URLs in XML instances continue to resolve for XML parsers
- Codelist CSS styles matching the site design system

**Canonical URL:** `https://schemas.isotc211.org/resources/codelists/codelists.xml#{CodelistId}`

Depends on: ISO-TC211/schemas#78 (merged)
Closes #67