### PR TITLE
feat: add Codelist Catalogues link to index page

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -54,6 +54,12 @@ permalink: /
         </a>
       </li>
       <li>
+        <a href="/resources/codelists/">
+          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 12h.007v.008H3.75V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm-.375 5.25h.007v.008H3.75v-.008zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"/></svg>
+          Codelist Catalogues
+        </a>
+      </li>
+      <li>
         <a href="https://github.com/ISO-TC211/XML">
           <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"/></svg>
           ISO/TC 211 XML Maintenance Group (XMG)


### PR DESCRIPTION
Adds a link to the Codelist Catalogues page in the Resources section of the homepage.