### PR TITLE
feat: add Codelists to header nav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,8 @@ powered_by:
 nav:
   - title: About
     url: /about/
+  - title: Codelists
+    url: /resources/codelists/
   - title: News
     url: /news/
   - title: ISO/TC 211 Resources


### PR DESCRIPTION
Adds Codelists link to the header navigation bar so it is visible on every page.