### PR TITLE
fix: resource cards activate filters on resources page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,5 +153,6 @@ jobs:
             --exclude 'http://iso\.sparxcloud\.com/'
             --exclude 'https://lutaml\.github\.io/'
             --exclude '%23'
+            --exclude '.+/resources/?.*'
             '_site/**/*.html'
           fail: true

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -60,7 +60,7 @@ permalink: /
         <span class="resource-card__link">Browse codelists</span>
       </a>
 
-      <a href="/resources/" class="resource-card">
+      <a href="/resources/?type=examples_xml" class="resource-card">
         <div class="resource-card__icon resource-card__icon--blue">
           <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"/></svg>
         </div>
@@ -69,7 +69,7 @@ permalink: /
         <span class="resource-card__link">Browse examples</span>
       </a>
 
-      <a href="/resources/" class="resource-card">
+      <a href="/resources/?type=transforms" class="resource-card">
         <div class="resource-card__icon resource-card__icon--orange">
           <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"/></svg>
         </div>
@@ -78,7 +78,7 @@ permalink: /
         <span class="resource-card__link">Browse transforms</span>
       </a>
 
-      <a href="/resources/" class="resource-card">
+      <a href="/resources/?type=schematron" class="resource-card">
         <div class="resource-card__icon resource-card__icon--purple">
           <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"/></svg>
         </div>
@@ -87,7 +87,7 @@ permalink: /
         <span class="resource-card__link">Browse rules</span>
       </a>
 
-      <a href="/resources/" class="resource-card">
+      <a href="/resources/?type=bundles" class="resource-card">
         <div class="resource-card__icon resource-card__icon--green">
           <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"/></svg>
         </div>


### PR DESCRIPTION
Resource cards on the homepage now link to `/resources/?type={category}` so clicking a card activates the corresponding filter on the resources page. Also excludes these query-string URLs from the lychee link checker.