### PR TITLE
fix: enable future posts in Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ tagline: >-
   Implementation schemas for geographic information technology
 
 markdown: kramdown
+future: true
 
 collections:
   pages:


### PR DESCRIPTION
The June 11 blog post was not appearing because Jekyll skips posts with future dates by default. This adds `future: true` to `_config.yml`.